### PR TITLE
Refine locale parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function bestMatchingLocale (inputLocale, availableLocales) {
 }
 
 function parseLocaleIntoCodes (locale) {
-    var match = locale.match(/^(\w\w)(?:-(\w\w\w\w))?(?:-(\w\w))?\b/i);
+    var match = locale.match(/^(\w\w\w?)(?:-(\w\w\w\w))?(?:-(\w\w))?\b/i);
     var localeParts = [];
     if (match[1]) {
         match[1] = match[1].toLowerCase();

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function bestMatchingLocale (inputLocale, availableLocales) {
 }
 
 function parseLocaleIntoCodes (locale) {
-    var match = locale.match(/(\w\w)(?:-(\w\w\w\w))?(?:-(\w\w))?/i);
+    var match = locale.match(/^(\w\w)(?:-(\w\w\w\w))?(?:-(\w\w))?\b/i);
     var localeParts = [];
     if (match[1]) {
         match[1] = match[1].toLowerCase();


### PR DESCRIPTION
This change prevents `parseLocaleIntoCodes()` from matching in the middle of the locale identifier and adds support for three-letter ISO 639-3 language codes. For example, `spa-ES` (Spanish in Spain) was being parsed as the bogus language code `sp`, ignoring the country code.

/cc @bsudekum