### PR TITLE
Fail to parse locale if locale fails to match regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@ function bestMatchingLocale (inputLocale, availableLocales) {
     });
 
     var localeCodes = parseLocaleIntoCodes(inputLocale);
+    if (!localeCodes) {
+        return null;
+    }
 
     if (availableLocales.indexOf(inputLocale) > -1) return localeCodes.locale;
 
@@ -36,7 +39,10 @@ function bestMatchingLocale (inputLocale, availableLocales) {
     var availableLocaleCodes = availableLocales.map(parseLocaleIntoCodes);
 
     // Same language code and any script code (lng-Scpx) and the found language contains a script
-    var anyScript = availableLocaleCodes.find(function (localeCode) {
+    var anyScript = availableLocaleCodes.find(function (localeCode, idx) {
+        if (localeCode === null) {
+            throw 'Invalid available locale code "' + availableLocales[idx] + '".';
+        }
         return localeCode.language === languageCode && localeCode.script;
     });
     if (anyScript) {
@@ -56,6 +62,10 @@ function bestMatchingLocale (inputLocale, availableLocales) {
 
 function parseLocaleIntoCodes (locale) {
     var match = locale.match(/^(\w\w\w?)(?:-(\w\w\w\w))?(?:-(\w\w))?\b/i);
+    if (!match) {
+        return null;
+    }
+    
     var localeParts = [];
     if (match[1]) {
         match[1] = match[1].toLowerCase();

--- a/test.js
+++ b/test.js
@@ -22,6 +22,9 @@ tape('test bestMatchingLocale', function(t) {
     t.equal(locale.bestMatchingLocale('es-mx', availableLocales), 'es');
     t.equal(locale.bestMatchingLocale('zh-Hans-region', availableLocales), 'zh-Hans');
     t.equal(locale.bestMatchingLocale('pt-BR', availableLocales), 'pt-PT');
+    t.throws(function () {
+        locale.bestMatchingLocale('en', ['foobar']);
+    }, /foobar/);
     t.end();
 });
 
@@ -40,11 +43,21 @@ tape('test parseLocaleIntoCodes', function(t) {
         region: 'MX'
     });
 
+    t.deepEqual(locale.parseLocaleIntoCodes('spa-ES'), {
+        locale: 'spa-ES',
+        language: 'spa',
+        script: undefined,
+        region: 'ES'
+    });
+
     t.deepEqual(locale.parseLocaleIntoCodes('zh-hans-HK'), {
         locale: 'zh-Hans-HK',
         language: 'zh',
         script: 'Hans',
         region: 'HK'
     });
+    
+    t.equal(locale.parseLocaleIntoCodes('foobar'), null);
+    
     t.end();
 });


### PR DESCRIPTION
Fixed a test failure caused by a latent bug exposed by #2. `parseLocaleIntoCodes()` should return `null` for a bogus regex. Also added various tests.

/cc @bsudekum